### PR TITLE
Replaced unsafe eval with ast.literal_eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ same data structure as the csv serializer.
 # Examples
 
 ```python
+import ast
 import io
 from typing import Any, TypeVar
 
@@ -87,7 +88,7 @@ class Mapper(BaseMapper):
 
     @staticmethod
     def map_deserialize(record: Record, data: bytes) -> Record:
-        _data = eval(data)
+        _data = ast.literal_eval(data)
         record.age = int(_data.get('age'))
         record.name = _data.get('name')
 

--- a/serde_components/serializers/csv_serializer.py
+++ b/serde_components/serializers/csv_serializer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import ast
 import io
 import csv
 from typing import Iterable, Type, TypeVar
@@ -23,7 +24,7 @@ class CsvSerializer(BaseSerializer):
         for record in records:
             b_data: bytes = mapper.map_serialize(record)
             data = b_data.decode('utf-8')
-            mapped_data.append(eval(data))
+            mapped_data.append(ast.literal_eval(data))
 
         assert len(mapped_data) > 1
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import ast
 import io
 from typing import Any, TypeVar
 
@@ -32,7 +33,7 @@ class Mapper(BaseMapper):
 
     @staticmethod
     def map_deserialize(record: Record, data: bytes) -> Record:
-        _data = eval(data)
+        _data = ast.literal_eval(data.decode('utf-8'))
         record.age = int(_data.get('age'))
         record.name = _data.get('name')
 
@@ -41,7 +42,7 @@ class Mapper(BaseMapper):
 
 def test_general_mapper():
     t = Record(name='testName', age=10)
-    data = eval(Mapper.map_serialize(t))
+    data = ast.literal_eval(Mapper.map_serialize(t).decode('utf-8'))
     golden_data = {
         'age': 10,
         'name': 'testName',


### PR DESCRIPTION
This pr replaces all `eval()` calls with [ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval). This is
specifically done since `eval` executes code without checking if the code is safe or not. `ast.literal_eval` will check if the string passed in is one of the following type:
`[strings, bytes, numbers, tuples, lists, dicts, sets, booleans, None, Ellipsis]`






A quote from the documentation
> This function had been documented as “safe” in the past without defining what that meant. That was misleading. This is specifically designed not to execute Python code, unlike the more general [eval()](https://docs.python.org/3/library/functions.html#eval). There is no namespace, no name lookups, or ability to call out. But it is not free from attack: A relatively small input can lead to memory exhaustion or to C stack exhaustion, crashing the process. There is also the possibility for excessive CPU consumption denial of service on some inputs. Calling it on untrusted data is thus not recommended.