### PR TITLE
Added python version matrix for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
     name: Pytest
     needs: black
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10, 3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test_master.yml
+++ b/.github/workflows/test_master.yml
@@ -9,6 +9,9 @@ jobs:
     name: Pytest
     needs: black
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10, 3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This pr adds a version matrix to ensure all tests pass on all supported python versions. Currently these are:
- 3.8
- 3.9
- 3.10
- 3.11

python 3.8 end of life is 27 Jun 2023.