### PR TITLE
Added a BaseRecord to help the type checker

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,4 +2,9 @@ coverage:
   status:
     patch:
       default:
-        target: 100%
+        target: 80%
+        threshold: 10%
+    project:
+      default:
+        target: 80%
+        threshold: 10%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,15 +1,5 @@
 coverage:
-  range: 80..100
-  round: down
-  precision: 1
   status:
-    project:
+    patch:
       default:
-        threshold: 1%
-
-ignore:
-  - "tests"
-
-comment:
-  layout: "files"
-  require_changes: yes
+        target: 100%

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,3 +69,15 @@ jobs:
         run: |
           pip install black
           black -S --check .
+
+  mypy:
+    name: Mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update pip
+        run: pip install --upgrade pip
+      - name: Setup mypy
+        run: pip install mypy==v0.991
+      - name: Run mypy
+        run: mypy serde_components/

--- a/.github/workflows/test_master.yml
+++ b/.github/workflows/test_master.yml
@@ -68,3 +68,15 @@ jobs:
         run: |
           pip install black
           black -S --check .
+
+  mypy:
+    name: Mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update pip
+        run: pip install --upgrade pip
+      - name: Setup mypy
+        run: pip install mypy==v0.991
+      - name: Run mypy
+        run: mypy serde_components/

--- a/serde_components/__init__.py
+++ b/serde_components/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from . import deserializers
 from . import mappers
+from . import record
 from . import serializers

--- a/serde_components/deserializers/base.py
+++ b/serde_components/deserializers/base.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 import abc
-from typing import Type, TypeVar, IO
+from typing import Type, IO
 
 from ..mappers import BaseMapper
-
-T = TypeVar('T')
+from ..record import BaseRecord as R
 
 
 class BaseDeserializer(metaclass=abc.ABCMeta):
     """
-    This base class defines the interface that all deserializers must implement.
-    All methods that require implementation are marked with the
+    This base class defines the interface that all deserializers must
+    implement. All methods that require implementation are marked with the
     @abc.abstractmethod decorator.
 
     Because this base does not know about the derived deserializers desired
@@ -19,7 +18,7 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def deserialize(record: T, mapper: Type[BaseMapper], data: bytes) -> T:
+    def deserialize(record: R, mapper: Type[BaseMapper], data: bytes) -> R:
         """
         This method is the main way to interact with an instance of a class
         derived from this base.
@@ -28,8 +27,8 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
 
     @classmethod
     def deserialize_from_file(
-        cls, record: T, mapper: Type[BaseMapper], file_object: IO[bytes]
-    ) -> T:
+        cls, record: R, mapper: Type[BaseMapper], file_object: IO[bytes]
+    ) -> R:
         """
         A convenience method that reads data from a file object and maps it to
         the record with the passed in mapper.

--- a/serde_components/deserializers/csv_deserializer.py
+++ b/serde_components/deserializers/csv_deserializer.py
@@ -32,9 +32,9 @@ class CsvDeserializer(BaseDeserializer):
         return records
 
     @classmethod
-    def deserialize_from_file(
+    def deserialize_from_file(  # type: ignore
         cls, record: Iter[R], mapper: Type[BaseMapper], file_object: IO[bytes]
-    ) -> R:
+    ) -> Iter[R]:
         """
         This method only gets overwriten to change the accepted types.
         """

--- a/serde_components/deserializers/csv_deserializer.py
+++ b/serde_components/deserializers/csv_deserializer.py
@@ -1,25 +1,27 @@
 # -*- coding: utf-8 -*-
 import io
 import csv
-from typing import Iterable, Type, TypeVar
+from typing import IO, Type
+from typing import Iterable as Iter
 
 from .base import BaseDeserializer
 from ..mappers import BaseMapper
-
-T = TypeVar('T')
+from ..record import BaseRecord as R
 
 
 class CsvDeserializer(BaseDeserializer):
     @staticmethod
-    def deserialize(
-        records: Iterable[T], mapper: Type[BaseMapper], data: bytes
-    ) -> Iterable[T]:
+    def deserialize(  # type: ignore
+        records: Iter[R], mapper: Type[BaseMapper], data: bytes
+    ) -> Iter[R]:
         """
         This method takes in a iterable over the records and maps the data from
-        a given csv.
+        a given csv. It takes an iterable since a csv will contain rows which
+        should correspond with a single record.
 
-        It takes an iterable since a csv will contain rows which should
-        correspond with a single record.
+        This class takes a different type than the BaseSerializer, it does not
+        make sense for a csv serializer to only map a single record. For this
+        reason the type checking is ignored.
         """
         file_object = io.StringIO(data.decode('utf-8'))
         dict_reader = csv.DictReader(file_object)
@@ -28,3 +30,15 @@ class CsvDeserializer(BaseDeserializer):
             mapper.map_deserialize(record, str(row).encode('utf-8'))
 
         return records
+
+    @classmethod
+    def deserialize_from_file(
+        cls, record: Iter[R], mapper: Type[BaseMapper], file_object: IO[bytes]
+    ) -> R:
+        """
+        This method only gets overwriten to change the accepted types.
+        """
+        r = record
+        m = mapper
+        f = file_object
+        return super().deserialize_from_file(r, m, f)  # type: ignore

--- a/serde_components/deserializers/json_deserializer.py
+++ b/serde_components/deserializers/json_deserializer.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 import json
-from typing import Type, TypeVar
+from typing import Type
 
 from .base import BaseDeserializer
 from ..mappers import BaseMapper
-
-T = TypeVar('T')
+from ..record import BaseRecord as R
 
 
 class JsonDeserializer(BaseDeserializer):
     @staticmethod
-    def deserialize(record: T, mapper: Type[BaseMapper], data: bytes) -> T:
+    def deserialize(record: R, mapper: Type[BaseMapper], data: bytes) -> R:
         json_data: bytes = str(json.loads(data)).encode('utf-8')
         mapper.map_deserialize(record, json_data)
 

--- a/serde_components/deserializers/toml_deserializer.py
+++ b/serde_components/deserializers/toml_deserializer.py
@@ -10,7 +10,7 @@ PYTHON_VERSION_ERROR = 'Your python version does not support this component'
 
 
 if sys.version_info.minor >= 11:
-    import tomllib
+    import tomllib  # type: ignore
 
 
 class TomlDeserializer(BaseDeserializer):

--- a/serde_components/deserializers/toml_deserializer.py
+++ b/serde_components/deserializers/toml_deserializer.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from typing import Type, TypeVar
+from typing import Type
 import sys
 
 from .base import BaseDeserializer
 from ..mappers import BaseMapper
+from ..record import BaseRecord as R
 
 PYTHON_VERSION_ERROR = 'Your python version does not support this component'
 
@@ -12,12 +13,12 @@ if sys.version_info.minor >= 11:
     import tomllib
 
 
-T = TypeVar('T')
-
-
 class TomlDeserializer(BaseDeserializer):
     @staticmethod
-    def deserialize(record: T, mapper: Type[BaseMapper], data: bytes) -> T:
+    def deserialize(record: R, mapper: Type[BaseMapper], data: bytes) -> R:
+        """
+        This method is only available in python versions 3.11 and later.
+        """
         # tomllib.loads does not take in bytestrings like json.loads does
         _data: str = data.decode('utf-8')
 

--- a/serde_components/mappers/base.py
+++ b/serde_components/mappers/base.py
@@ -1,17 +1,23 @@
 # -*- coding: utf-8 -*-
 import abc
-from typing import Any, TypeVar
 
-T = TypeVar('T')
+from ..record import BaseRecord
 
 
 class BaseMapper(metaclass=abc.ABCMeta):
+    """
+    This class defines the interface that is required in order to use a derived
+    class as a mapper object. It is technically possible to implement a class
+    without inheriting from this base class, but the type checker will complain
+    about it.
+    """
+
     @staticmethod
     @abc.abstractmethod
-    def map_serialize(record: Any) -> bytes:
+    def map_serialize(record: BaseRecord) -> bytes:
         raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod
-    def map_deserialize(record: T, data: bytes) -> T:
+    def map_deserialize(record: BaseRecord, data: bytes) -> BaseRecord:
         raise NotImplementedError

--- a/serde_components/record/__init__.py
+++ b/serde_components/record/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .base import BaseRecord

--- a/serde_components/record/base.py
+++ b/serde_components/record/base.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+class BaseRecord:
+    """
+    This class acts as a marker class, as such it does not add any
+    functionality. This is done so the type checker can ensure the object
+    passed into the mapper, serializer or deserializer is marked correctly.
+    """
+
+    pass

--- a/serde_components/serializers/base.py
+++ b/serde_components/serializers/base.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import abc
-from typing import Any, Type, IO
+from typing import Type, IO
 
 from ..mappers import BaseMapper
+from ..record import BaseRecord as R
 
 
 class BaseSerializer(metaclass=abc.ABCMeta):
@@ -17,7 +18,7 @@ class BaseSerializer(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def serialize(record: Any, mapper: Type[BaseMapper]) -> bytes:
+    def serialize(record: R, mapper: Type[BaseMapper]) -> bytes:
         """
         This method is the main way to interact with an instance of a class
         derived from this base.
@@ -26,7 +27,7 @@ class BaseSerializer(metaclass=abc.ABCMeta):
 
     @classmethod
     def serialize_to_file(
-        cls, record: Any, mapper: Type[BaseMapper], file_object: IO[bytes]
+        cls, record: R, mapper: Type[BaseMapper], file_object: IO[bytes]
     ) -> None:
         """
         A convenience method that maps the record with the passed in mapper and

--- a/serde_components/serializers/csv_serializer.py
+++ b/serde_components/serializers/csv_serializer.py
@@ -2,23 +2,25 @@
 import ast
 import io
 import csv
-from typing import Iterable, Type, TypeVar
+from typing import IO, Type
+from typing import Iterable as Iter
 
 from .base import BaseSerializer
 from ..mappers import BaseMapper
-
-T = TypeVar('T')
+from ..record import BaseRecord as R
 
 
 class CsvSerializer(BaseSerializer):
     @staticmethod
-    def serialize(records: Iterable[T], mapper: Type[BaseMapper]) -> bytes:
+    def serialize(records: Iter[R], mapper: Type[BaseMapper]) -> bytes:  # type: ignore
         """
         This method takes in a iterable over the records and maps the data from
-        a to a csv format.
+        a to a csv format. It takes an iterable since a csv will contain rows
+        which should correspond with a single record.
 
-        It takes an iterable since a csv will contain rows which should
-        correspond with a single record.
+        This class takes a different type than the BaseSerializer, it does not
+        make sense for a csv serializer to only map a single record. For this
+        reason the type checking is ignored.
         """
         mapped_data = []
         for record in records:
@@ -37,3 +39,15 @@ class CsvSerializer(BaseSerializer):
             writer.writerow(row)
 
         return file_object.getvalue().encode('utf-8')
+
+    @classmethod
+    def serialize_to_file(  # type: ignore
+        cls, record: Iter[R], mapper: Type[BaseMapper], file_object: IO[bytes]
+    ) -> None:
+        """
+        This method only gets overwriten to change the accepted types.
+        """
+        r = record
+        m = mapper
+        f = file_object
+        return super().serialize_to_file(r, m, f)  # type: ignore

--- a/serde_components/serializers/json_serializer.py
+++ b/serde_components/serializers/json_serializer.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 import ast
 import json
-from typing import Any, Type, TypeVar
+from typing import Type
 
 from .base import BaseSerializer
 from ..mappers import BaseMapper
+from ..record import BaseRecord
 
 
 class JsonSerializer(BaseSerializer):
     @staticmethod
-    def serialize(record: Any, mapper: Type[BaseMapper]) -> bytes:
+    def serialize(record: BaseRecord, mapper: Type[BaseMapper]) -> bytes:
         _data: bytes = mapper.map_serialize(record)
         data = ast.literal_eval(_data.decode('utf-8'))
         json_data: bytes = json.dumps(data).encode('utf-8')

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -3,14 +3,15 @@ import ast
 import io
 from typing import Any, TypeVar
 
+from serde_components.deserializers import CsvDeserializer
 from serde_components.mappers import BaseMapper
-from serde_components.serializers import CsvSerializer, JsonSerializer
-from serde_components.deserializers import CsvDeserializer, JsonDeserializer
+from serde_components.record.base import BaseRecord
+from serde_components.serializers import CsvSerializer
 
 T = TypeVar('T')
 
 
-class Record:
+class Record(BaseRecord):
     def __init__(self, name, age):
         self.name = name
         self.age = age
@@ -36,7 +37,7 @@ class Mapper(BaseMapper):
         if isinstance(age, str):
             try:
                 record.age = int(age)
-            except:
+            except:  # noqa
                 record.age = age
         if isinstance(age, int):
             record.age = age
@@ -90,7 +91,11 @@ def test_csv_deserializer_from_filebuffer():
         data = golden_file_object.read()[:-1]
     file_object = io.BytesIO(data)
     records = [Record(name='aaa', age=i + 100) for i in range(10)]
-    records = CsvDeserializer.deserialize_from_file(records, Mapper, file_object)
+    records = CsvDeserializer.deserialize_from_file(
+        records,
+        Mapper,
+        file_object,
+    )
     golden_records = [Record(name='testName', age=i) for i in range(10)]
 
     assert records == golden_records

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -55,84 +55,84 @@ def test_general_mapper():
     assert data == golden_data
 
 
-# def test_json_serializer():
-#     t = Record(name='testName', age=10)
-#     json_data = JsonSerializer.serialize(t, Mapper).decode()
-#
-#     assert json_data == "{\"age\": 10, \"name\": \"testName\"}"
-#
-#
-# def test_json_serializer_to_file1():
-#     t = Record(name='TestFileName', age=100)
-#     file_object = io.BytesIO(b'')
-#     JsonSerializer.serialize_to_file(t, Mapper, file_object)
-#
-#     with open('tests/data/json/record1.json', 'rb') as golden_file_object:
-#         golden_bytes = golden_file_object.read()[:-1]
-#
-#     assert file_object.getvalue() == golden_bytes
-#
-#
-# def test_json_serializer_to_file2():
-#     t = Record(name=None, age=None)
-#     file_object = io.BytesIO(b'')
-#     JsonSerializer.serialize_to_file(t, Mapper, file_object)
-#     golden_bytes = b'{"age": null, "name": null}'
-#
-#     assert file_object.getvalue() == golden_bytes
-#
-#
-# def test_json_serializer_to_file3():
-#     t = Record(name=100, age='TestFileName')
-#     file_object = io.BytesIO(b'')
-#     JsonSerializer.serialize_to_file(t, Mapper, file_object)
-#
-#     with open('tests/data/json/record3.json', 'rb') as golden_file_object:
-#         golden_bytes = golden_file_object.read()[:-1]
-#
-#     assert file_object.getvalue() == golden_bytes
-#
-#
-# def test_json_deserializer():
-#     t = Record(name='', age=0)
-#     json_data = b'"{\'age\': 10, \'name\': \'testName\'}"'
-#     JsonDeserializer.deserialize(t, Mapper, json_data)
-#     golden_record = Record(name='testName', age=10)
-#
-#     assert t == golden_record
-#
-#
-# def test_json_deserializer_from_filebuffer():
-#     t = Record(name='', age=0)
-#     file_object = io.BytesIO(b'"{\'age\': 10, \'name\': \'testName\'}"')
-#     JsonDeserializer.deserialize_from_file(t, Mapper, file_object)
-#     golden_record = Record(name='testName', age=10)
-#
-#     assert t == golden_record
-#
-#
-# def test_json_deserializer_actual_file1():
-#     with open('tests/data/json/record1.json', 'rb') as file_object:
-#         record = Record(name='', age=0)
-#         JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
-#         golden_record = Record(name='TestFileName', age=100)
-#
-#     assert record, golden_record
-#
-#
-# def test_json_deserializer_actual_file2():
-#     with open('tests/data/json/record2.json', 'rb') as file_object:
-#         record = Record(name='', age=0)
-#         JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
-#         golden_record = Record(name=None, age=None)
-#
-#     assert record, golden_record
-#
-#
-# def test_json_deserializer_actual_file3():
-#     with open('tests/data/json/record3.json', 'rb') as file_object:
-#         record = Record(name='', age=0)
-#         JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
-#         golden_record = Record(name=10, age='TestFileName')
-#
-#     assert record, golden_record
+def test_json_serializer():
+    t = Record(name='testName', age=10)
+    json_data = JsonSerializer.serialize(t, Mapper).decode()
+
+    assert json_data == "{\"age\": 10, \"name\": \"testName\"}"
+
+
+def test_json_serializer_to_file1():
+    t = Record(name='TestFileName', age=100)
+    file_object = io.BytesIO(b'')
+    JsonSerializer.serialize_to_file(t, Mapper, file_object)
+
+    with open('tests/data/json/record1.json', 'rb') as golden_file_object:
+        golden_bytes = golden_file_object.read()[:-1]
+
+    assert file_object.getvalue() == golden_bytes
+
+
+def test_json_serializer_to_file2():
+    t = Record(name=None, age=None)
+    file_object = io.BytesIO(b'')
+    JsonSerializer.serialize_to_file(t, Mapper, file_object)
+    golden_bytes = b'{"age": null, "name": null}'
+
+    assert file_object.getvalue() == golden_bytes
+
+
+def test_json_serializer_to_file3():
+    t = Record(name=100, age='TestFileName')
+    file_object = io.BytesIO(b'')
+    JsonSerializer.serialize_to_file(t, Mapper, file_object)
+
+    with open('tests/data/json/record3.json', 'rb') as golden_file_object:
+        golden_bytes = golden_file_object.read()[:-1]
+
+    assert file_object.getvalue() == golden_bytes
+
+
+def test_json_deserializer():
+    t = Record(name='', age=0)
+    json_data = b'"{\'age\': 10, \'name\': \'testName\'}"'
+    JsonDeserializer.deserialize(t, Mapper, json_data)
+    golden_record = Record(name='testName', age=10)
+
+    assert t == golden_record
+
+
+def test_json_deserializer_from_filebuffer():
+    t = Record(name='', age=0)
+    file_object = io.BytesIO(b'"{\'age\': 10, \'name\': \'testName\'}"')
+    JsonDeserializer.deserialize_from_file(t, Mapper, file_object)
+    golden_record = Record(name='testName', age=10)
+
+    assert t == golden_record
+
+
+def test_json_deserializer_actual_file1():
+    with open('tests/data/json/record1.json', 'rb') as file_object:
+        record = Record(name='', age=0)
+        JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
+        golden_record = Record(name='TestFileName', age=100)
+
+    assert record, golden_record
+
+
+def test_json_deserializer_actual_file2():
+    with open('tests/data/json/record2.json', 'rb') as file_object:
+        record = Record(name='', age=0)
+        JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
+        golden_record = Record(name=None, age=None)
+
+    assert record, golden_record
+
+
+def test_json_deserializer_actual_file3():
+    with open('tests/data/json/record3.json', 'rb') as file_object:
+        record = Record(name='', age=0)
+        JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
+        golden_record = Record(name=10, age='TestFileName')
+
+    assert record, golden_record

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -55,84 +55,84 @@ def test_general_mapper():
     assert data == golden_data
 
 
-def test_json_serializer():
-    t = Record(name='testName', age=10)
-    json_data = JsonSerializer.serialize(t, Mapper).decode()
-
-    assert json_data == "{\"age\": 10, \"name\": \"testName\"}"
-
-
-def test_json_serializer_to_file1():
-    t = Record(name='TestFileName', age=100)
-    file_object = io.BytesIO(b'')
-    JsonSerializer.serialize_to_file(t, Mapper, file_object)
-
-    with open('tests/data/json/record1.json', 'rb') as golden_file_object:
-        golden_bytes = golden_file_object.read()[:-1]
-
-    assert file_object.getvalue() == golden_bytes
-
-
-def test_json_serializer_to_file2():
-    t = Record(name=None, age=None)
-    file_object = io.BytesIO(b'')
-    JsonSerializer.serialize_to_file(t, Mapper, file_object)
-    golden_bytes = b'{"age": null, "name": null}'
-
-    assert file_object.getvalue() == golden_bytes
-
-
-def test_json_serializer_to_file3():
-    t = Record(name=100, age='TestFileName')
-    file_object = io.BytesIO(b'')
-    JsonSerializer.serialize_to_file(t, Mapper, file_object)
-
-    with open('tests/data/json/record3.json', 'rb') as golden_file_object:
-        golden_bytes = golden_file_object.read()[:-1]
-
-    assert file_object.getvalue() == golden_bytes
-
-
-def test_json_deserializer():
-    t = Record(name='', age=0)
-    json_data = b'"{\'age\': 10, \'name\': \'testName\'}"'
-    JsonDeserializer.deserialize(t, Mapper, json_data)
-    golden_record = Record(name='testName', age=10)
-
-    assert t == golden_record
-
-
-def test_json_deserializer_from_filebuffer():
-    t = Record(name='', age=0)
-    file_object = io.BytesIO(b'"{\'age\': 10, \'name\': \'testName\'}"')
-    JsonDeserializer.deserialize_from_file(t, Mapper, file_object)
-    golden_record = Record(name='testName', age=10)
-
-    assert t == golden_record
-
-
-def test_json_deserializer_actual_file1():
-    with open('tests/data/json/record1.json', 'rb') as file_object:
-        record = Record(name='', age=0)
-        JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
-        golden_record = Record(name='TestFileName', age=100)
-
-    assert record, golden_record
-
-
-def test_json_deserializer_actual_file2():
-    with open('tests/data/json/record2.json', 'rb') as file_object:
-        record = Record(name='', age=0)
-        JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
-        golden_record = Record(name=None, age=None)
-
-    assert record, golden_record
-
-
-def test_json_deserializer_actual_file3():
-    with open('tests/data/json/record3.json', 'rb') as file_object:
-        record = Record(name='', age=0)
-        JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
-        golden_record = Record(name=10, age='TestFileName')
-
-    assert record, golden_record
+# def test_json_serializer():
+#     t = Record(name='testName', age=10)
+#     json_data = JsonSerializer.serialize(t, Mapper).decode()
+#
+#     assert json_data == "{\"age\": 10, \"name\": \"testName\"}"
+#
+#
+# def test_json_serializer_to_file1():
+#     t = Record(name='TestFileName', age=100)
+#     file_object = io.BytesIO(b'')
+#     JsonSerializer.serialize_to_file(t, Mapper, file_object)
+#
+#     with open('tests/data/json/record1.json', 'rb') as golden_file_object:
+#         golden_bytes = golden_file_object.read()[:-1]
+#
+#     assert file_object.getvalue() == golden_bytes
+#
+#
+# def test_json_serializer_to_file2():
+#     t = Record(name=None, age=None)
+#     file_object = io.BytesIO(b'')
+#     JsonSerializer.serialize_to_file(t, Mapper, file_object)
+#     golden_bytes = b'{"age": null, "name": null}'
+#
+#     assert file_object.getvalue() == golden_bytes
+#
+#
+# def test_json_serializer_to_file3():
+#     t = Record(name=100, age='TestFileName')
+#     file_object = io.BytesIO(b'')
+#     JsonSerializer.serialize_to_file(t, Mapper, file_object)
+#
+#     with open('tests/data/json/record3.json', 'rb') as golden_file_object:
+#         golden_bytes = golden_file_object.read()[:-1]
+#
+#     assert file_object.getvalue() == golden_bytes
+#
+#
+# def test_json_deserializer():
+#     t = Record(name='', age=0)
+#     json_data = b'"{\'age\': 10, \'name\': \'testName\'}"'
+#     JsonDeserializer.deserialize(t, Mapper, json_data)
+#     golden_record = Record(name='testName', age=10)
+#
+#     assert t == golden_record
+#
+#
+# def test_json_deserializer_from_filebuffer():
+#     t = Record(name='', age=0)
+#     file_object = io.BytesIO(b'"{\'age\': 10, \'name\': \'testName\'}"')
+#     JsonDeserializer.deserialize_from_file(t, Mapper, file_object)
+#     golden_record = Record(name='testName', age=10)
+#
+#     assert t == golden_record
+#
+#
+# def test_json_deserializer_actual_file1():
+#     with open('tests/data/json/record1.json', 'rb') as file_object:
+#         record = Record(name='', age=0)
+#         JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
+#         golden_record = Record(name='TestFileName', age=100)
+#
+#     assert record, golden_record
+#
+#
+# def test_json_deserializer_actual_file2():
+#     with open('tests/data/json/record2.json', 'rb') as file_object:
+#         record = Record(name='', age=0)
+#         JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
+#         golden_record = Record(name=None, age=None)
+#
+#     assert record, golden_record
+#
+#
+# def test_json_deserializer_actual_file3():
+#     with open('tests/data/json/record3.json', 'rb') as file_object:
+#         record = Record(name='', age=0)
+#         JsonDeserializer.deserialize_from_file(record, Mapper, file_object)
+#         golden_record = Record(name=10, age='TestFileName')
+#
+#     assert record, golden_record

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
 import ast
 import io
-from typing import Any, TypeVar
-
-from serde_components.mappers import BaseMapper
-from serde_components.serializers import JsonSerializer
+from typing import Any
 
 from serde_components.deserializers import JsonDeserializer
+from serde_components.mappers import BaseMapper
+from serde_components.record.base import BaseRecord
+from serde_components.serializers import JsonSerializer
 
-T = TypeVar('T')
 
-
-class Record:
+class Record(BaseRecord):
     def __init__(self, name, age):
         self.name = name
         self.age = age
@@ -37,7 +35,7 @@ class Mapper(BaseMapper):
         if isinstance(age, str):
             try:
                 record.age = int(age)
-            except:
+            except:  # noqa
                 record.age = age
         if isinstance(age, int):
             record.age = age

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -61,78 +61,78 @@ def test_general_mapper():
     assert data == golden_data
 
 
-# def test_toml_deserializer():
-#     t = Record(name='', age=0)
-#     toml_data = b'age = 10\nname = "testName"\n'
-#     if sys.version_info.minor < 11:
-#         with pytest.raises(ImportError):
-#             TomlDeserializer.deserialize(t, Mapper, toml_data)
-#     else:
-#         TomlDeserializer.deserialize(t, Mapper, toml_data)
-#         golden_record = Record(name='testName', age=10)
-#
-#         assert t == golden_record
-#
-#
-# def test_toml_deserializer_from_filebuffer():
-#     t = Record(name='', age=0)
-#     file_object = io.BytesIO(b'age = 10\nname = "testName"\n')
-#     if sys.version_info.minor < 11:
-#         with pytest.raises(ImportError):
-#             TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
-#     else:
-#         TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
-#         golden_record = Record(name='testName', age=10)
-#
-#         assert t == golden_record
-#
-#
-# def test_toml_deserializer_actual_file1():
-#     with open('tests/data/toml/record1.toml', 'rb') as file_object:
-#         record = Record(name='', age=0)
-#         if sys.version_info.minor < 11:
-#             with pytest.raises(ImportError):
-#                 TomlDeserializer.deserialize_from_file(
-#                     record,
-#                     Mapper,
-#                     file_object,
-#                 )
-#         else:
-#             TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
-#         golden_record = Record(name='TestFileName', age=100)
-#
-#     assert record, golden_record
-#
-#
-# def test_toml_deserializer_actual_file2():
-#     with open('tests/data/toml/record2.toml', 'rb') as file_object:
-#         record = Record(name='', age=0)
-#         if sys.version_info.minor < 11:
-#             with pytest.raises(ImportError):
-#                 TomlDeserializer.deserialize_from_file(
-#                     record,
-#                     Mapper,
-#                     file_object,
-#                 )
-#         else:
-#             TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
-#         golden_record = Record(name=None, age=None)
-#
-#     assert record, golden_record
-#
-#
-# def test_toml_deserializer_actual_file3():
-#     with open('tests/data/toml/record3.toml', 'rb') as file_object:
-#         record = Record(name='', age=0)
-#         if sys.version_info.minor < 11:
-#             with pytest.raises(ImportError):
-#                 TomlDeserializer.deserialize_from_file(
-#                     record,
-#                     Mapper,
-#                     file_object,
-#                 )
-#         else:
-#             TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
-#         golden_record = Record(name=10, age='TestFileName')
-#
-#     assert record, golden_record
+def test_toml_deserializer():
+    t = Record(name='', age=0)
+    toml_data = b'age = 10\nname = "testName"\n'
+    if sys.version_info.minor < 11:
+        with pytest.raises(ImportError):
+            TomlDeserializer.deserialize(t, Mapper, toml_data)
+    else:
+        TomlDeserializer.deserialize(t, Mapper, toml_data)
+        golden_record = Record(name='testName', age=10)
+
+        assert t == golden_record
+
+
+def test_toml_deserializer_from_filebuffer():
+    t = Record(name='', age=0)
+    file_object = io.BytesIO(b'age = 10\nname = "testName"\n')
+    if sys.version_info.minor < 11:
+        with pytest.raises(ImportError):
+            TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
+    else:
+        TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
+        golden_record = Record(name='testName', age=10)
+
+        assert t == golden_record
+
+
+def test_toml_deserializer_actual_file1():
+    with open('tests/data/toml/record1.toml', 'rb') as file_object:
+        record = Record(name='', age=0)
+        if sys.version_info.minor < 11:
+            with pytest.raises(ImportError):
+                TomlDeserializer.deserialize_from_file(
+                    record,
+                    Mapper,
+                    file_object,
+                )
+        else:
+            TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
+        golden_record = Record(name='TestFileName', age=100)
+
+    assert record, golden_record
+
+
+def test_toml_deserializer_actual_file2():
+    with open('tests/data/toml/record2.toml', 'rb') as file_object:
+        record = Record(name='', age=0)
+        if sys.version_info.minor < 11:
+            with pytest.raises(ImportError):
+                TomlDeserializer.deserialize_from_file(
+                    record,
+                    Mapper,
+                    file_object,
+                )
+        else:
+            TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
+        golden_record = Record(name=None, age=None)
+
+    assert record, golden_record
+
+
+def test_toml_deserializer_actual_file3():
+    with open('tests/data/toml/record3.toml', 'rb') as file_object:
+        record = Record(name='', age=0)
+        if sys.version_info.minor < 11:
+            with pytest.raises(ImportError):
+                TomlDeserializer.deserialize_from_file(
+                    record,
+                    Mapper,
+                    file_object,
+                )
+        else:
+            TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
+        golden_record = Record(name=10, age='TestFileName')
+
+    assert record, golden_record

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -61,78 +61,78 @@ def test_general_mapper():
     assert data == golden_data
 
 
-def test_toml_deserializer():
-    t = Record(name='', age=0)
-    toml_data = b'age = 10\nname = "testName"\n'
-    if sys.version_info.minor < 11:
-        with pytest.raises(ImportError):
-            TomlDeserializer.deserialize(t, Mapper, toml_data)
-    else:
-        TomlDeserializer.deserialize(t, Mapper, toml_data)
-        golden_record = Record(name='testName', age=10)
-
-        assert t == golden_record
-
-
-def test_toml_deserializer_from_filebuffer():
-    t = Record(name='', age=0)
-    file_object = io.BytesIO(b'age = 10\nname = "testName"\n')
-    if sys.version_info.minor < 11:
-        with pytest.raises(ImportError):
-            TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
-    else:
-        TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
-        golden_record = Record(name='testName', age=10)
-
-        assert t == golden_record
-
-
-def test_toml_deserializer_actual_file1():
-    with open('tests/data/toml/record1.toml', 'rb') as file_object:
-        record = Record(name='', age=0)
-        if sys.version_info.minor < 11:
-            with pytest.raises(ImportError):
-                TomlDeserializer.deserialize_from_file(
-                    record,
-                    Mapper,
-                    file_object,
-                )
-        else:
-            TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
-        golden_record = Record(name='TestFileName', age=100)
-
-    assert record, golden_record
-
-
-def test_toml_deserializer_actual_file2():
-    with open('tests/data/toml/record2.toml', 'rb') as file_object:
-        record = Record(name='', age=0)
-        if sys.version_info.minor < 11:
-            with pytest.raises(ImportError):
-                TomlDeserializer.deserialize_from_file(
-                    record,
-                    Mapper,
-                    file_object,
-                )
-        else:
-            TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
-        golden_record = Record(name=None, age=None)
-
-    assert record, golden_record
-
-
-def test_toml_deserializer_actual_file3():
-    with open('tests/data/toml/record3.toml', 'rb') as file_object:
-        record = Record(name='', age=0)
-        if sys.version_info.minor < 11:
-            with pytest.raises(ImportError):
-                TomlDeserializer.deserialize_from_file(
-                    record,
-                    Mapper,
-                    file_object,
-                )
-        else:
-            TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
-        golden_record = Record(name=10, age='TestFileName')
-
-    assert record, golden_record
+# def test_toml_deserializer():
+#     t = Record(name='', age=0)
+#     toml_data = b'age = 10\nname = "testName"\n'
+#     if sys.version_info.minor < 11:
+#         with pytest.raises(ImportError):
+#             TomlDeserializer.deserialize(t, Mapper, toml_data)
+#     else:
+#         TomlDeserializer.deserialize(t, Mapper, toml_data)
+#         golden_record = Record(name='testName', age=10)
+#
+#         assert t == golden_record
+#
+#
+# def test_toml_deserializer_from_filebuffer():
+#     t = Record(name='', age=0)
+#     file_object = io.BytesIO(b'age = 10\nname = "testName"\n')
+#     if sys.version_info.minor < 11:
+#         with pytest.raises(ImportError):
+#             TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
+#     else:
+#         TomlDeserializer.deserialize_from_file(t, Mapper, file_object)
+#         golden_record = Record(name='testName', age=10)
+#
+#         assert t == golden_record
+#
+#
+# def test_toml_deserializer_actual_file1():
+#     with open('tests/data/toml/record1.toml', 'rb') as file_object:
+#         record = Record(name='', age=0)
+#         if sys.version_info.minor < 11:
+#             with pytest.raises(ImportError):
+#                 TomlDeserializer.deserialize_from_file(
+#                     record,
+#                     Mapper,
+#                     file_object,
+#                 )
+#         else:
+#             TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
+#         golden_record = Record(name='TestFileName', age=100)
+#
+#     assert record, golden_record
+#
+#
+# def test_toml_deserializer_actual_file2():
+#     with open('tests/data/toml/record2.toml', 'rb') as file_object:
+#         record = Record(name='', age=0)
+#         if sys.version_info.minor < 11:
+#             with pytest.raises(ImportError):
+#                 TomlDeserializer.deserialize_from_file(
+#                     record,
+#                     Mapper,
+#                     file_object,
+#                 )
+#         else:
+#             TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
+#         golden_record = Record(name=None, age=None)
+#
+#     assert record, golden_record
+#
+#
+# def test_toml_deserializer_actual_file3():
+#     with open('tests/data/toml/record3.toml', 'rb') as file_object:
+#         record = Record(name='', age=0)
+#         if sys.version_info.minor < 11:
+#             with pytest.raises(ImportError):
+#                 TomlDeserializer.deserialize_from_file(
+#                     record,
+#                     Mapper,
+#                     file_object,
+#                 )
+#         else:
+#             TomlDeserializer.deserialize_from_file(record, Mapper, file_object)
+#         golden_record = Record(name=10, age='TestFileName')
+#
+#     assert record, golden_record

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -8,11 +8,13 @@ import pytest
 
 from serde_components.mappers import BaseMapper
 from serde_components.deserializers import TomlDeserializer
+from serde_components.record import BaseRecord
+
 
 T = TypeVar('T')
 
 
-class Record:
+class Record(BaseRecord):
     def __init__(self, name, age):
         self.name = name
         self.age = age
@@ -39,7 +41,7 @@ class Mapper(BaseMapper):
         if isinstance(age, str):
             try:
                 record.age = int(age)
-            except:
+            except:  # noqa
                 record.age = age
         if isinstance(age, int):
             record.age = age


### PR DESCRIPTION
This pr adds the `BaseRecord` type as a replacement for the `Any` type. This `BaseRecord` type does not add any functionality, but is rather used as a marker type to help the type checker along. 