### PR TITLE
Added docstrings to all Serializers and Deserializers

### DIFF
--- a/serde_components/deserializers/base.py
+++ b/serde_components/deserializers/base.py
@@ -24,6 +24,16 @@ class BaseDeserializer(abc.ABC, Generic[Record]):
         """
         This method is the main way to interact with an instance of a class
         derived from this base.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+
+        Returns:
+            The passed record with data mapped from the data.
         """
         raise NotImplementedError
 
@@ -37,6 +47,21 @@ class BaseDeserializer(abc.ABC, Generic[Record]):
         """
         A convenience method that reads data from a file object and maps it to
         the record with the passed in mapper.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+            file_object: Some file-like object that can be read from. This
+                includes io.BytesIO and file objects opened in byte mode.
+
+        Returns:
+            The passed record with data mapped from the data.
+
+        Raises:
+            ValueError: An error has occured while doing I/O operations.
         """
         data = file_object.read()
         return cls.deserialize(record, mapper, data)

--- a/serde_components/deserializers/csv_deserializer.py
+++ b/serde_components/deserializers/csv_deserializer.py
@@ -22,6 +22,17 @@ class CsvDeserializer(BaseDeserializer, Generic[Record]):
         This class takes a different type than the BaseSerializer, it does not
         make sense for a csv serializer to only map a single record. For this
         reason the type checking is ignored.
+
+        Args:
+            records: Some iterable of concrete record instances that inherits
+                from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+
+        Returns:
+            The passed record with data mapped from the data.
         """
         file_object = io.StringIO(data.decode('utf-8'))
         dict_reader = csv.DictReader(file_object)
@@ -39,7 +50,27 @@ class CsvDeserializer(BaseDeserializer, Generic[Record]):
         file_object: IO[bytes],
     ) -> Iter[Record]:
         """
-        This method only gets overwriten to change the accepted types.
+        A convenience method that reads data from a file object and maps it to
+        the record with the passed in mapper.
+
+        This method only gets overwriten to change the accepted types, see
+        BaseDeserializer for more details.
+
+        Args:
+            records: Some iterable of concrete record instances that inherits
+                from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+            file_object: Some file-like object that can be read from. This
+                includes io.BytesIO and file objects opened in byte mode.
+
+        Returns:
+            The passed record with data mapped from the data.
+
+        Raises:
+            ValueError: An error has occured while doing I/O operations.
         """
         r = record
         m = mapper

--- a/serde_components/deserializers/json_deserializer.py
+++ b/serde_components/deserializers/json_deserializer.py
@@ -16,3 +16,6 @@ class JsonDeserializer(BaseDeserializer):
         mapper.map_deserialize(record, json_data)  # type: ignore
 
         return record
+
+
+JsonDeserializer.deserialize.__doc__ = BaseDeserializer.deserialize.__doc__

--- a/serde_components/deserializers/toml_deserializer.py
+++ b/serde_components/deserializers/toml_deserializer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Type
+from typing import IO, Type
 import sys
 
 from .base import BaseDeserializer
@@ -20,6 +20,20 @@ class TomlDeserializer(BaseDeserializer):
     ) -> Record:
         """
         This method is only available in python versions 3.11 and later.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+
+        Returns:
+            The passed record with data mapped from the data.
+
+        Raises:
+            NameError: Tomllib is not available on the system. This class is
+                only supported on python versions 3.11 and later.
         """
         # tomllib.loads does not take in bytestrings like json.loads does
         _data: str = data.decode('utf-8')
@@ -33,3 +47,30 @@ class TomlDeserializer(BaseDeserializer):
         mapper.map_deserialize(record, toml_data)  # type:ignore
 
         return record
+
+    @classmethod
+    def deserialize_from_file(
+        cls,
+        record: Record,
+        mapper: Type[BaseMapper[Record]],
+        file_object: IO[bytes],
+    ) -> Record:
+        """
+        This method is only available in python versions 3.11 and later.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+
+        Returns:
+            The passed record with data mapped from the data.
+
+        Raises:
+            NameError: Tomllib is not available on the system. This class is
+                only supported on python versions 3.11 and later.
+            ValueError: An error has occured while doing I/O operations.
+        """
+        return super().deserialize_from_file(record, mapper, file_object)

--- a/serde_components/serializers/base.py
+++ b/serde_components/serializers/base.py
@@ -22,6 +22,14 @@ class BaseSerializer(abc.ABC, Generic[Record]):
         """
         This method is the main way to interact with an instance of a class
         derived from this base.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+
+        Returns:
+            A bytestring of the data encoded by the specific Serializer.
         """
         raise NotImplementedError
 
@@ -32,6 +40,16 @@ class BaseSerializer(abc.ABC, Generic[Record]):
         """
         A convenience method that maps the record with the passed in mapper and
         writes it to a file object.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            file_object: Some file-like object that can be read from. This
+                includes io.BytesIO and file objects opened in byte mode.
+
+        Raises:
+            ValueError: An error has occured while doing I/O operations.
         """
         data = cls.serialize(record, mapper)
         file_object.write(data)

--- a/serde_components/serializers/csv_serializer.py
+++ b/serde_components/serializers/csv_serializer.py
@@ -21,6 +21,17 @@ class CsvSerializer(BaseSerializer, Generic[Record]):
         This class takes a different type than the BaseSerializer, it does not
         make sense for a csv serializer to only map a single record. For this
         reason the type checking is ignored.
+
+        Args:
+            records: Some iterable of concrete record instances that inherits
+                from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            data: Some bytestring that represents the record in a format
+                specified by the concrete Deserializer.
+
+        Returns:
+            A bytestring of the data encoded by the specific Serializer.
         """
         mapped_data = []
         for record in records:
@@ -45,7 +56,19 @@ class CsvSerializer(BaseSerializer, Generic[Record]):
         cls, record: Iter[Record], mapper: Type[BaseMapper], file_object: IO[bytes]
     ) -> None:
         """
+        A convenience method that maps the record with the passed in mapper and
+        writes it to a file object.
         This method only gets overwriten to change the accepted types.
+
+        Args:
+            record: Some concrete record instance that inherits from BaseRecord.
+            mapper: Some concrete mapper class that inherits from BaseMapper,
+                this mapper should be specific for the type of record passed in.
+            file_object: Some file-like object that can be read from. This
+                includes io.BytesIO and file objects opened in byte mode.
+
+        Raises:
+            ValueError: An error has occured while doing I/O operations.
         """
         r = record
         m = mapper

--- a/serde_components/serializers/json_serializer.py
+++ b/serde_components/serializers/json_serializer.py
@@ -16,3 +16,6 @@ class JsonSerializer(BaseSerializer, Generic[Record]):
         json_data: bytes = json.dumps(data).encode('utf-8')
 
         return json_data
+
+
+JsonSerializer.serialize.__doc__ = BaseSerializer.serialize.__doc__


### PR DESCRIPTION
This pr adds some docstrings to all `Serializers` and `Deserializers`.

Mainly to make sure there is no switching between editor and documentation.